### PR TITLE
Fix tests by making formatting levels optional

### DIFF
--- a/test/tools/generator/while_statement_test.exs
+++ b/test/tools/generator/while_statement_test.exs
@@ -17,7 +17,7 @@ defmodule ESTree.Tools.Generator.WhileStatement.Test do
       Builder.block_statement([]),
       Builder.identifier(:test)
     )
-    assert Generator.generate(ast) == "do {} while(test)"  
+    assert Generator.generate(ast) == "do {} while(test);"  
   end
 
 end


### PR DESCRIPTION
Without these changes current master seems to fail with many issues related to whitespace in the output.

This PR addresses this by making the `level` parameter truly optional.

If this approach is acceptable I can take a look at formatting-specific tests. I think the current tests are good because they are simply formatted.