### PR TITLE
Fixup and spec for object formatting

### DIFF
--- a/test/tools/generator/formatting_test.exs
+++ b/test/tools/generator/formatting_test.exs
@@ -1,0 +1,50 @@
+defmodule ESTree.Tools.Generator.Formatting.Test do
+  use ShouldI
+  alias ESTree.Tools.Builder
+  alias ESTree.Tools.Generator
+
+  should "format objects" do
+    ast = Builder.object_expression([
+      Builder.property(
+        Builder.identifier(:key),
+        Builder.identifier(:value)
+      ),
+      Builder.property(
+        Builder.identifier(:key),
+        Builder.identifier(:value)
+      )
+    ])
+    assert Generator.generate(ast, 0) <> "\n" ==
+"""
+{
+  key: value,
+  key: value
+}
+"""
+  end
+
+  should "format objects in function calls" do
+    ast = Builder.call_expression(
+      Builder.identifier(:foo),
+      [
+        Builder.object_expression([
+          Builder.property(
+            Builder.identifier(:key),
+            Builder.identifier(:value)
+          ),
+          Builder.property(
+            Builder.identifier(:key),
+            Builder.identifier(:value)
+          )
+        ])
+      ]
+    )
+    assert Generator.generate(ast, 0) <> "\n" ==
+"""
+foo({
+  key: value,
+  key: value
+})
+"""
+  end
+end

--- a/test/tools/generator/object_expression_test.exs
+++ b/test/tools/generator/object_expression_test.exs
@@ -34,7 +34,7 @@ defmodule ESTree.Tools.Generator.ObjectExpression.Test do
         Builder.identifier(:value1)
       )
     ])
-    assert Generator.generate(ast) == "{key: value, key1: value1}" 
+    assert Generator.generate(ast) == "{key: value,key1: value1}"
   end
 
 
@@ -51,7 +51,7 @@ defmodule ESTree.Tools.Generator.ObjectExpression.Test do
         :set
       ),
     ])
-    assert Generator.generate(ast) == "{get key() {}, set key(p) {}}" 
+    assert Generator.generate(ast) == "{get key() {},set key(p) {}}"
   end
 
   should "convert object when properties contains getter and setter methods" do
@@ -71,7 +71,7 @@ defmodule ESTree.Tools.Generator.ObjectExpression.Test do
         true
       ),
     ])
-    assert Generator.generate(ast) == "{key() {}, key(p) {}}" 
+    assert Generator.generate(ast) == "{key() {},key(p) {}}"
   end
 
   should "convert object when properties contains shorthand properties" do


### PR DESCRIPTION
First attempt at Object literal formatting. An object is formatted as:

* The previous indentation level
* A `{` character
* a newline and a new indent level
* a list of key/values; joined by `,#{newline}#{indent}`
* a newline
* The previous indentation level
* a `}` character