### PR TITLE
Use JSXText instead of Literal

### DIFF
--- a/lib/es_tree/jsx_element.ex
+++ b/lib/es_tree/jsx_element.ex
@@ -3,7 +3,7 @@ defmodule ESTree.JSXElement do
     type: binary,
     loc: ESTree.SourceLocation.t | nil,
     openingElement: ESTree.JSXOpeningElement.t,
-    children: [ESTree.Literal.t | ESTree.JSXExpressionContainer.t | ESTree.JSXElement.t],
+    children: [ESTree.JSXText.t | ESTree.JSXExpressionContainer.t | ESTree.JSXElement.t],
     closingElement: ESTree.JSXClosingElement.t | nil
   }
   defstruct type: "JSXElement", loc: nil, openingElement: nil, children: [], closingElement: nil

--- a/lib/es_tree/jsx_text.ex
+++ b/lib/es_tree/jsx_text.ex
@@ -1,0 +1,8 @@
+defmodule ESTree.JSXText do
+  @type t :: %ESTree.JSXText{
+    type: binary,
+    value: binary,
+    loc: ESTree.SourceLocation.t | nil
+  }
+  defstruct type: "JSXText", loc: nil, value: nil
+end

--- a/lib/es_tree/tools/builder.ex
+++ b/lib/es_tree/tools/builder.ex
@@ -883,13 +883,23 @@ defmodule ESTree.Tools.Builder do
 
   @spec jsx_element(
     ESTree.JSXOpeningElement.t,
-    [ESTree.Literal.t | ESTree.JSXExpressionContainer.t | ESTree.JSXElement.t],
+    [ESTree.JSXText.t | ESTree.JSXExpressionContainer.t | ESTree.JSXElement.t],
     ESTree.JSXClosingElement.t | nil,
     ESTree.SourceLocation.t | nil
   ) :: ESTree.JSXElement.t
   def jsx_element(openingElement, children \\ [], closingElement \\ nil, loc \\ nil) do
     %ESTree.JSXElement{ 
       openingElement: openingElement, children: children, closingElement: closingElement, loc: loc
+    }
+  end
+
+  @spec jsx_text(
+    binary,
+    ESTree.SourceLocation.t | nil
+  ) :: ESTree.JSXText.t
+  def jsx_text(value, loc \\ nil) do
+    %ESTree.JSXText{
+      value: value, loc: loc
     }
   end
 end

--- a/lib/es_tree/tools/generator.ex
+++ b/lib/es_tree/tools/generator.ex
@@ -752,7 +752,15 @@ defmodule ESTree.Tools.Generator do
   end
 
   def do_generate(%ESTree.JSXElement{ openingElement: openingElement, children: children, closingElement: closingElement }, level) do
-    "#{ generate(openingElement) }#{ Enum.map(children, &generate(&1, calculate_next_level(level))) |> Enum.join(" ") }#{ generate(closingElement) }"
+    "#{ generate(openingElement) }#{ Enum.map(children, &generate(&1, calculate_next_level(level))) |> Enum.join }#{ generate(closingElement) }"
+  end
+
+  def do_generate(%ESTree.JSXText{ value: value }, level) do
+    value
+    |> String.replace("{", "&lcub;")
+    |> String.replace("}", "&rcub;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 
   defp convert_string_characters(str) do

--- a/test/tools/generator/jsx_test.exs
+++ b/test/tools/generator/jsx_test.exs
@@ -148,4 +148,29 @@ defmodule ESTree.Tools.Generator.JSX.Test do
 
     assert Generator.generate(ast) == "<Test.xml><div/></Test.xml>"
   end
+
+  should "handle inner text" do
+    ast = Builder.jsx_element(
+      Builder.jsx_opening_element(
+        Builder.jsx_identifier(
+          "Test"
+        )
+      ),
+      [
+        Builder.jsx_text("counter: "),
+        Builder.jsx_expression_container(
+          Builder.identifier(:count)
+        ),
+        Builder.jsx_text("."),
+        Builder.jsx_text(" Escaped: { } < >"),
+      ],
+      Builder.jsx_closing_element(
+        Builder.jsx_identifier(
+          "Test"
+        )
+      )
+    )
+
+    assert Generator.generate(ast) == "<Test>counter: {count}. Escaped: &lcub; &rcub; &lt; &gt;</Test>"
+  end
 end


### PR DESCRIPTION
Hello Bryan,

I've tried to pass string literals children to `jsx_element`, and it generated strings like this `<div>'hello'</div>` instead of `<div>hello</div>`. 

I'm new to Elixir and compiling stuff, but maybe this PR will be ok.
`JSXText` is just string, but with escaping of `{}<>` chars.

Also, i've replaced `join(" ")` to `join("")` in `jsx_element` children generation, because spaces can be undesirable in some cases, and always can be set explicitly.

Best regards, Sergio.