### PR TITLE
Handle edge case when string literal is a JSX child

### DIFF
--- a/lib/es_tree/tools/generator.ex
+++ b/lib/es_tree/tools/generator.ex
@@ -752,7 +752,26 @@ defmodule ESTree.Tools.Generator do
   end
 
   def do_generate(%ESTree.JSXElement{ openingElement: openingElement, children: children, closingElement: closingElement }, level) do
-    "#{ generate(openingElement) }#{ Enum.map(children, &generate(&1, calculate_next_level(level))) |> Enum.join(" ") }#{ generate(closingElement) }"
+    "#{ generate(openingElement) }#{ generate_jsx_children(children, calculate_next_level(level)) }#{ generate(closingElement) }"
+  end
+
+  defp generate_jsx_children(children, level) do
+    gen_fn = fn
+      %ESTree.Literal{value: value} when is_binary(value) ->
+        convert_jsx_text(value)
+      other ->
+        generate(other, level)
+    end
+
+    children |> Enum.map(gen_fn) |> Enum.join
+  end
+
+  defp convert_jsx_text(str) do
+    str
+    |> String.replace("{", "&lcub;")
+    |> String.replace("}", "&rcub;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 
   defp convert_string_characters(str) do

--- a/test/tools/generator/jsx_test.exs
+++ b/test/tools/generator/jsx_test.exs
@@ -148,4 +148,28 @@ defmodule ESTree.Tools.Generator.JSX.Test do
 
     assert Generator.generate(ast) == "<Test.xml><div/></Test.xml>"
   end
+
+  should "handle inner text" do
+    ast = Builder.jsx_element(
+      Builder.jsx_opening_element(
+        Builder.jsx_identifier(
+          "Test"
+        )
+      ),
+      [
+        Builder.literal("counter: "),
+        Builder.jsx_expression_container(
+          Builder.identifier(:count)
+        ),
+        Builder.literal("."),
+      ],
+      Builder.jsx_closing_element(
+        Builder.jsx_identifier(
+          "Test"
+        )
+      )
+    )
+
+    assert Generator.generate(ast) == "<Test>counter: {count}.</Test>"
+  end
 end


### PR DESCRIPTION
What do you think about this fix?

Looks like `\n` and `\t` escaping aren't necessary for jsx, but for `<>{}` it makes sense.