### PR TITLE
Expressions can be used in variable declaration

### DIFF
--- a/lib/es_tree/tools/generator.ex
+++ b/lib/es_tree/tools/generator.ex
@@ -189,18 +189,14 @@ defmodule ESTree.Tools.Generator do
     "debugger;"
   end
 
-  def do_generate(%ESTree.VariableDeclaration{kind: kind, declarations: [declaration]}, _level) when kind in [:var, :let, :const] do
-    declaration = generate(declaration)
-
-    "#{to_string(kind)} #{declaration};"
-  end
-
   def do_generate(%ESTree.VariableDeclaration{kind: kind, declarations: declarations}, _level) when kind in [:var, :let, :const] do
 
-    ids = Enum.map_join(declarations, ",",  fn(x) -> generate(x.id) end)
-    inits = Enum.map_join(declarations, ",", fn(x) -> generate(x.init) end)
+    declarators = declarations
+    |> Enum.map_join(", ", fn(x) ->
+      generate(x)
+    end)
 
-    "#{to_string(kind)} #{ids} = #{inits};"
+    "#{to_string(kind)} #{declarators};"
   end
 
   def do_generate(%ESTree.VariableDeclarator{id: id, init: nil}, _level) do

--- a/test/tools/generator/variable_declaration_test.exs
+++ b/test/tools/generator/variable_declaration_test.exs
@@ -1,0 +1,49 @@
+defmodule ESTree.Tools.Generator.VariableDeclaration.Test do
+  use ShouldI
+
+  alias ESTree.Tools.{Builder, Generator}
+
+  should "emit var declaration" do
+    ast = Builder.variable_declaration([])
+
+    assert Generator.generate(ast) == "var ;"
+  end
+
+  should "emit let declaration" do
+    ast = Builder.variable_declaration([], :let)
+
+    assert Generator.generate(ast) == "let ;"
+  end
+
+  should "emit const declaration" do
+    ast = Builder.variable_declaration([], :const)
+
+    assert Generator.generate(ast) == "const ;"
+  end
+
+  should "add variable declarator" do
+    ast = Builder.variable_declaration([
+      Builder.variable_declarator(Builder.identifier(:a))
+    ])
+
+    assert Generator.generate(ast) == "var a;"
+  end
+
+  should "add variable declarators with corresponding inits" do
+    ast = Builder.variable_declaration([
+      Builder.variable_declarator(Builder.identifier(:a), Builder.literal(1)),
+      Builder.variable_declarator(Builder.identifier(:b)),
+      Builder.variable_declarator(
+        Builder.identifier(:c),
+        Builder.binary_expression(
+          :+,
+          Builder.identifier(:a),
+          Builder.literal(2)
+        )
+      )
+    ])
+
+    assert Generator.generate(ast) == "var a = 1, b, c = a + 2;"
+  end
+
+end


### PR DESCRIPTION
Was:
  var a, b, c = 1, 2, 3;

Become:
  var a = 1, b = 2, c = 3;

Can be used as:
  var a = 1, b, c = a + 2;