### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,14 +5,14 @@ defmodule ESTree.Mixfile do
     [app: :estree,
      version: "2.4.1",
      elixir: "~> 1.0",
-     deps: deps,
-     description: description,
-     package: package,
+     deps: deps(),
+     description: description(),
+     package: package(),
      source_url: "https://github.com/bryanjos/elixir-estree"]
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do
@@ -20,7 +20,7 @@ defmodule ESTree.Mixfile do
       {:earmark, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.12", only: :dev},
       {:dialyze, "~> 0.2", only: :dev},
-      {:shouldi, only: :test}
+      {:shouldi, "~> 0.3.2", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
-  "shouldi": {:hex, :shouldi, "0.3.0", "ae3fb3cec3328057377a0aa750aa1bb9f8b321ba054e1e2c7211512c383fb6ff", [:mix], []}}
+  "shouldi": {:hex, :shouldi, "0.3.2", "971f614669b5f37c03507ba643bb8e59aa165ac50ca66d726c9db53be255e440", [:mix], []}}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.start(formatters: [ShouldI.CLIFormatter])
+ExUnit.start()
 
 Code.require_file "support.ex", __DIR__


### PR DESCRIPTION
Also updates ShouldI to version 0.3.2 and other dependencies to newer versions as well.